### PR TITLE
Updated checksums after version change of RPMs on snort.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the snort cookbook.
 
+## v4.0.1 (2018-12-14)
+
+- Updated checksums for the snort package on CentOS and Fedora
+
 ## v4.0.0 (2018-08-28)
 
 - Drop Chef-12 support

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Installs Snort IDS packages'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.0.0'
+version          '4.0.1'
 chef_version     '>= 13.0'
 source_url       'https://github.com/sous-chefs/snort'
 issues_url       'https://github.com/sous-chefs/snort/issues'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -29,9 +29,9 @@ property :interface, [String, nil]
 property :checksum, [String, nil], default: lazy {
   case node['platform_family']
   when 'rhel'
-    '3bc90510b006b2f3f45bda3a54fb004d4a41afd271e861d8210fe44b83d8d675'
+    'c0b9d7e855424b63efda0d443a2da30d16537ed827e7fdeb72a7e2a8c98d8393'
   when 'fedora'
-    '075a376bdbb34876a34045bd84c800957cbb7af12ab966cadb1ad967aef1087f'
+    '381f2b634ccb9559523e94062de9ffbbdcc5fc3c0f8cbfb51d2eaaa417533c95'
   end
 }
 property :daq_checksum, [String, nil], default: lazy {


### PR DESCRIPTION
## Description

Corrects checksums so that CentOS nodes can download current (as-of-writing) snort and daq RPMS from snort.org.

### Issues Resolved

https://github.com/sous-chefs/snort/issues/23

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable

No new functionality, just a bugfix.

The kitchen test suite doesn't pass before this change (spec seems like it's missing an it block for centos, didn't look carefully at the others). Running kitchen test default-centos-7 before and after this commit does show a change from failing behaviour to expected behaviour.