### PR TITLE
Split to capture status results from compile steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the snort cookbook.
 
+## v4.0.2 (2019-06-25)
+
+- Added CircleCI 2.0 support
+
 ## v4.0.1 (2018-12-14)
 
 - Updated checksums for the snort package on CentOS and Fedora

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -10,7 +10,7 @@ module SnortCookbook
 
     def package_suffix
       if platform?('fedora')
-        '.f25'
+        '.f29'
       else
         '.centos7'
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Installs Snort IDS packages'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.0.1'
+version          '4.0.2'
 chef_version     '>= 13.0'
 source_url       'https://github.com/sous-chefs/snort'
 issues_url       'https://github.com/sous-chefs/snort/issues'

--- a/resources/compile.rb
+++ b/resources/compile.rb
@@ -57,21 +57,21 @@ action :compile do
 
   execute 'Compile DAQ' do
     cwd daq_path
-    command <<-EOH
-    ./configure
-    make
-    make install
-    EOH
+    command './configure && make && make install'
     action :nothing
   end
 
   execute 'Compile snort' do
     cwd snort_path
+    command './configure --enable-sourcefire --disable-open-appid && make && make install && ldconfig'
+    action :nothing
+
+    notifies :run, 'execute[Post-compile steps]', :immediately
+  end
+
+  execute 'Post-compile steps' do
+    cwd snort_path
     command <<-EOH
-      ./configure --enable-sourcefire
-      make
-      make install
-      ldconfig
       ln -s /usr/local/bin/snort /usr/sbin/snort
       cp #{snort_path}/etc/*.conf* /etc/snort
       cp #{snort_path}/etc/*.map* /etc/snort

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -29,9 +29,9 @@ property :interface, [String, nil]
 property :checksum, [String, nil], default: lazy {
   case node['platform_family']
   when 'rhel'
-    'c0a8655abe1b0342d1717faa9fb25546'
+    'F9357ED7867BF9ABBD29906843F1D24800425A2D350F01F3B954A5ACF510306D'
   when 'fedora'
-    '33c75aec804ed42c88a6ac51db61ea99'
+    'E93FB043A2C07B6D5AF397DE74BB0B9DBC929C0B5B635C183D35CEC344918159'
   end
 }
 property :daq_checksum, [String, nil], default: lazy {
@@ -98,17 +98,7 @@ action :create do
       # snort needs libnghttp2 from EPEL
       include_recipe 'yum-epel::default' if platform_family?('rhel')
 
-      daq_rpm = "daq-#{new_resource.daq_version}#{package_suffix}.x86_64.rpm"
-
-      remote_file "#{Chef::Config[:file_cache_path]}/#{daq_rpm}" do
-        source "https://www.snort.org/downloads/snort/#{daq_rpm}"
-        checksum new_resource.daq_checksum
-        mode '0644'
-      end
-
-      package 'daq' do
-        source "#{Chef::Config[:file_cache_path]}/#{daq_rpm}"
-      end
+      package 'daq'
 
       snort_rpm = "snort-#{new_resource.rpm_version + package_suffix}.x86_64.rpm"
 


### PR DESCRIPTION
## Description

* Disables the new open-appid feature so we don't need the new LuaJIT dependency.
* Uses bash shortcut syntax to ensure that each step succeeds and capture all the logs
* Splits out post-compile steps so these dependencies can be factored into full resources

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
