### PR TITLE
Drop support for poise_archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This file is used to list changes made in each version of the snort cookbook.
 ## Unreleased
 
 - Migrate to actions
-
+- Replace archive_file with archive_file *Breaking change*
 ## v4.0.2 (2019-06-25)
 
 - Added CircleCI 2.0 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the snort cookbook.
 
 - Migrate to actions
 - Replace archive_file with archive_file *Breaking change*
+
 ## v4.0.2 (2019-06-25)
 
 - Added CircleCI 2.0 support

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,14 +1,3 @@
-# Reference: http://danger.systems/reference.html
-
-# A pull request summary is required. Add a description of the pull request purpose.
-# Changelog must be updated for each pull request that changes code.
-# Warnings will be issued for:
-#    Pull request with more than 400 lines of code changed
-#    Pull reqest that change more than 5 lines without test changes
-# Failures will be issued for:
-#    Pull request without summary
-#    Pull requests with code changes without changelog entry
-
 def code_changes?
   code = %w(libraries attributes recipes resources files templates)
   code.each do |location|

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,9 +3,8 @@ maintainer       'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Installs Snort IDS packages'
-
 version          '4.0.2'
-chef_version     '>= 13.0'
+chef_version     '>= 15.0'
 source_url       'https://github.com/sous-chefs/snort'
 issues_url       'https://github.com/sous-chefs/snort/issues'
 
@@ -14,4 +13,3 @@ issues_url       'https://github.com/sous-chefs/snort/issues'
 end
 
 depends 'yum-epel'
-depends 'poise-archive'

--- a/resources/compile.rb
+++ b/resources/compile.rb
@@ -1,21 +1,3 @@
-#
-# Cookbook:: snort
-# Resource:: compile
-#
-# Copyright:: 2017, Webb Agile Solutions Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 property :daq_tar, String, required: true
 property :snort_tar, String, required: true
 property :snort_version, String, required: true
@@ -45,13 +27,21 @@ action :compile do
     end
   end
 
-  poise_archive new_resource.daq_tar do
-    destination daq_path
+  remote_file new_resource.daq_tar do
+    path "#{daq_path}.tar.gz"
+  end
+
+  archive_file "#{daq_path}.tar.gz" do
+    path daq_path
     notifies :run, 'execute[Compile DAQ]', :immediately
   end
 
-  poise_archive new_resource.snort_tar do
-    destination snort_path
+  remote_file new_resource.snort_tar do
+    path "#{snort_path}.tar.gz"
+  end
+
+  archive_file "#{snort_path}.tar.gz" do
+    path snort_path
     notifies :run, 'execute[Compile snort]', :immediately
   end
 
@@ -65,7 +55,6 @@ action :compile do
     cwd snort_path
     command './configure --enable-sourcefire --disable-open-appid && make && make install && ldconfig'
     action :nothing
-
     notifies :run, 'execute[Post-compile steps]', :immediately
   end
 

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,6 +1,5 @@
-property :home_net, String,     default: 'any'
-property :external_net, String, default: 'any'
-
+property :home_net, String,        default: 'any'
+property :external_net, String,    default: 'any'
 property :http_ports, String,      default: '80,81,311,383,591,593,901,1220,1414,1741,1830,2301,2381,2809,3037,3128,3702,4343,4848,5250,6988,7000,7001,7144,7145,7510,7777,7779,8000,8008,8014,8028,8080,8085,8088,8090,8118,8123,8180,8181,8243,8280,8300,8800,8888,8899,9000,9060,9080,9090,9091,9443,9999,11371,34443,34444,41080,50002,55555'
 property :shellcode_ports, String, default: '!80'
 property :oracle_ports, String,    default: '1024'
@@ -10,9 +9,8 @@ property :sip_ports, String,       default: '5060,5061,5600'
 property :file_data_ports, String, default: '$HTTP_PORTS,110,143'
 property :gtp_ports, String,       default: '2123,2152,3386'
 property :aim_servers, String,     default: '64.12.24.0/23,64.12.28.0/23,64.12.161.0/24,64.12.163.0/24,64.12.200.0/24,205.188.3.0/24,205.188.5.0/24,205.188.7.0/24,205.188.9.0/24,205.188.153.0/24,205.188.179.0/24,205.188.248.0/24'
-
-property :decoder_config, Array, default: ['disable_decode_alerts', 'disable_tcpopt_experimental_alerts', 'disable_tcpopt_obsolete_alerts', 'disable_tcpopt_ttcp_alerts', 'disable_tcpopt_alerts', 'disable_ipopt_alerts', 'checksum_mode: all']
-property :detection_config, Hash, default: {
+property :decoder_config, Array,   default: ['disable_decode_alerts', 'disable_tcpopt_experimental_alerts', 'disable_tcpopt_obsolete_alerts', 'disable_tcpopt_ttcp_alerts', 'disable_tcpopt_alerts', 'disable_ipopt_alerts', 'checksum_mode: all']
+property :detection_config, Hash,  default: {
   'config pcre_match_limit' => '3500',
   'config pcre_match_limit_recursion' => '1500',
   'config detection' => 'search-method ac-split search-optimize max-pattern-len 20',

--- a/resources/rules.rb
+++ b/resources/rules.rb
@@ -7,11 +7,11 @@ property :override_url, String
 action :create do
   remote_file 'snort tar' do
     source rules_url.to_s
-    path ::File.join(Chef::Config[:file_cache_path], 'snort')
+    path ::File.join(Chef::Config[:file_cache_path], 'snort.tar.gz')
   end
 
-  archive_file ::File.join(Chef::Config[:file_cache_path], 'snort') do
-    destination "#{new_resource.conf_dir}/rules"
+  archive_file ::File.join(Chef::Config[:file_cache_path], 'snort.tar.gz') do
+    destination ::File.join(new_resource.conf_dir, 'rules')
   end
 end
 

--- a/resources/rules.rb
+++ b/resources/rules.rb
@@ -5,7 +5,12 @@ property :download_type, String, equal_to: %w(community registered subscriber), 
 property :override_url, String
 
 action :create do
-  poise_archive rules_url.to_s do
+  remote_file 'snort tar' do
+    source rules_url.to_s
+    path ::File.join(Chef::Config[:file_cache_path], 'snort')
+  end
+
+  archive_file ::File.join(Chef::Config[:file_cache_path], 'snort') do
     destination "#{new_resource.conf_dir}/rules"
   end
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -2,6 +2,10 @@ describe file('/usr/sbin/snort') do
   it { should exist }
 end
 
+describe file('/etc/snort/rules/community.rules') do
+  it { should exist }
+end
+
 if os[:family] == 'redhat' || os[:family] == 'fedora'
   describe service('snortd') do
     it { should be_enabled }


### PR DESCRIPTION
# Description

This bumps the minimum version of this cookbook to Chef-15 due to
archive file:
https://docs.chef.io/resource_archive_file.html

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
