### PR TITLE
Test: Cookstyle Auto Corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of the snort cookbook.
 
 ## Unreleased
+- Cookstyle auto-corrections applied on 2025-04-14
 
 ## 5.0.11 - *2024-05-02*
 

--- a/resources/compile.rb
+++ b/resources/compile.rb
@@ -69,7 +69,7 @@ action :compile do
   end
 end
 
-action_class.class_eval do
+action_class do
   def daq_path
     "#{Chef::Config[:file_cache_path]}/daq"
   end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -124,6 +124,6 @@ action :create do
   end
 end
 
-action_class.class_eval do
+action_class do
   include SnortCookbook::Helpers
 end

--- a/resources/rules.rb
+++ b/resources/rules.rb
@@ -15,7 +15,7 @@ action :create do
   end
 end
 
-action_class.class_eval do
+action_class do
   def rules_url
     return new_resource.override_url unless new_resource.override_url.nil?
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -2,7 +2,7 @@ property :options, Array, default: ['-q']
 
 action :start do
   create_init
-  cleanup_old_service if node['init_package'] == 'systemd'
+  cleanup_old_service if systemd?
 
   service svc_name do
     supports status: true, restart: true
@@ -15,7 +15,7 @@ action :stop do
     supports status: true
     action :stop
     only_if { ::File.exist?("/etc/init/#{svc_name}.conf") } if node['init_package'] == 'init'
-    only_if { ::File.exist?("/etc/systemd/system/#{svc_name}.service") } if node['init_package'] == 'systemd'
+    only_if { ::File.exist?("/etc/systemd/system/#{svc_name}.service") } if systemd?
   end
 end
 
@@ -27,7 +27,7 @@ action :restart do
 end
 
 action :enable do
-  cleanup_old_service if node['init_package'] == 'systemd'
+  cleanup_old_service if systemd?
   create_init
 
   service svc_name do
@@ -41,13 +41,13 @@ action :disable do
     supports status: true
     action :disable
     only_if { ::File.exist?("/etc/init/tomcat_#{new_resource.instance_name}.conf") } if node['init_package'] == 'init'
-    only_if { ::File.exist?("/etc/systemd/system/#{svc_name}.service") } if node['init_package'] == 'systemd'
+    only_if { ::File.exist?("/etc/systemd/system/#{svc_name}.service") } if systemd?
   end
 end
 
-action_class.class_eval do
+action_class do
   def create_init
-    if node['init_package'] == 'systemd'
+    if systemd?
 
       execute 'Load systemd unit file' do
         command 'systemctl daemon-reload'


### PR DESCRIPTION
## Cookstyle Auto-corrections

This PR applies automatic cookstyle fixes using the latest version.

### Changes Made

```
Cookstyle Output:
Cookstyle exit status: 1
Inspecting 14 files
....RRRRR.W...

Offenses:

resources/compile.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
property :daq_tar, String, required: true
^
resources/compile.rb:72:1: R: [Correctable] Chef/Modernize/ClassEvalActionClass: In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)
action_class.class_eval do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/config.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
property :home_net, String,        default: 'any'
^
resources/install.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
#
^
resources/install.rb:127:1: R: [Correctable] Chef/Modernize/ClassEvalActionClass: In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)
action_class.class_eval do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/rules.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
property :oinkcode, [String, nil] # Supply this to download registered/subscriber rules
^
resources/rules.rb:18:1: R: [Correctable] Chef/Modernize/ClassEvalActionClass: In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)
action_class.class_eval do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
property :options, Array, default: ['-q']
^
resources/service.rb:5:26: R: [Correctable] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
  cleanup_old_service if node['init_package'] == 'systemd'
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:18:77: R: [Correctable] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
    only_if { ::File.exist?("/etc/systemd/system/#{svc_name}.service") } if node['init_package'] == 'systemd'
                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:30:26: R: [Correctable] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
  cleanup_old_service if node['init_package'] == 'systemd'
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:44:77: R: [Correctable] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
    only_if { ::File.exist?("/etc/systemd/system/#{svc_name}.service") } if node['init_package'] == 'systemd'
                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:48:1: R: [Correctable] Chef/Modernize/ClassEvalActionClass: In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)
action_class.class_eval do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:50:8: R: [Correctable] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
    if node['init_package'] == 'systemd'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/unit/recipes/default_spec.rb:6:18: W: Chef/Deprecations/DeprecatedChefSpecPlatform: Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3 (https://docs.chef.io/workstation/cookstyle/chef_deprecations_deprecatedchefspecplatform)
  let(:runner) { ChefSpec::ServerRunner.new(platform: 'debian', version: '8', step_into: ['snort_install']) }
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

14 files inspected, 15 offenses detected, 9 offenses auto-correctable


Auto-correction Output:
Inspecting 14 files
....RRRRR.W...

Offenses:

resources/compile.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
property :daq_tar, String, required: true
^
resources/compile.rb:72:1: R: [Corrected] Chef/Modernize/ClassEvalActionClass: In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)
action_class.class_eval do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/config.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
property :home_net, String,        default: 'any'
^
resources/install.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
#
^
resources/install.rb:127:1: R: [Corrected] Chef/Modernize/ClassEvalActionClass: In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)
action_class.class_eval do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/rules.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
property :oinkcode, [String, nil] # Supply this to download registered/subscriber rules
^
resources/rules.rb:18:1: R: [Corrected] Chef/Modernize/ClassEvalActionClass: In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)
action_class.class_eval do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:1:1: R: Chef/Deprecations/ResourceWithoutUnifiedTrue: Set unified_mode true in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
property :options, Array, default: ['-q']
^
resources/service.rb:5:26: R: [Corrected] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
  cleanup_old_service if node['init_package'] == 'systemd'
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:18:77: R: [Corrected] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
    only_if { ::File.exist?("/etc/systemd/system/#{svc_name}.service") } if node['init_package'] == 'systemd'
                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:30:26: R: [Corrected] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
  cleanup_old_service if node['init_package'] == 'systemd'
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:44:77: R: [Corrected] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
    only_if { ::File.exist?("/etc/systemd/system/#{svc_name}.service") } if node['init_package'] == 'systemd'
                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:48:1: R: [Corrected] Chef/Modernize/ClassEvalActionClass: In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)
action_class.class_eval do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/service.rb:50:8: R: [Corrected] Chef/Modernize/UseChefLanguageSystemdHelper: Chef Infra Client 15.5 and later include a systemd? helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)
    if node['init_package'] == 'systemd'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/unit/recipes/default_spec.rb:6:18: W: Chef/Deprecations/DeprecatedChefSpecPlatform: Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3 (https://docs.chef.io/workstation/cookstyle/chef_deprecations_deprecatedchefspecplatform)
  let(:runner) { ChefSpec::ServerRunner.new(platform: 'debian', version: '8', step_into: ['snort_install']) }
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

14 files inspected, 15 offenses detected, 9 offenses corrected


Changes Made:
M	resources/compile.rb
M	resources/install.rb
M	resources/rules.rb
M	resources/service.rb
 M resources/compile.rb
 M resources/install.rb
 M resources/rules.rb
 M resources/service.rb
```

### Verification Steps

- [ ] All tests pass
- [ ] Cookbook version has been bumped if appropriate
- [ ] Changelog has been updated if appropriate

Automated PR created by GitHub Cookstyle Runner
